### PR TITLE
feat: add card binding and payment freeze scaffolding

### DIFF
--- a/src/Api/Ameria/Request/Struct/CancelPayment.php
+++ b/src/Api/Ameria/Request/Struct/CancelPayment.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Ngs\AmeriaPayment\Api\Ameria\Request\Struct;
+
+class CancelPayment extends BaseRequestStruct
+{
+    protected array $apiCredentials = ['Username', 'Password'];
+
+    /** @var string */
+    public $PaymentID;
+
+    /** @var string */
+    public $Username;
+
+    /** @var string */
+    public $Password;
+}

--- a/src/Api/Ameria/Request/Struct/ConfirmPayment.php
+++ b/src/Api/Ameria/Request/Struct/ConfirmPayment.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Ngs\AmeriaPayment\Api\Ameria\Request\Struct;
+
+class ConfirmPayment extends BaseRequestStruct
+{
+    protected array $apiCredentials = ['Username', 'Password'];
+
+    /** @var string */
+    public $PaymentID;
+
+    /** @var string */
+    public $Username;
+
+    /** @var string */
+    public $Password;
+
+    /** @var float */
+    public $Amount;
+}

--- a/src/Api/Ameria/Request/Struct/MakeBindingPayment.php
+++ b/src/Api/Ameria/Request/Struct/MakeBindingPayment.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Ngs\AmeriaPayment\Api\Ameria\Request\Struct;
+
+class MakeBindingPayment extends BaseRequestStruct
+{
+    protected array $apiCredentials = ['Username', 'Password', 'ClientID'];
+
+    /** @var string */
+    public $ClientID;
+
+    /** @var string */
+    public $Username;
+
+    /** @var string */
+    public $Password;
+
+    /** @var string */
+    public $Currency;
+
+    /** @var string */
+    public $Description;
+
+    /** @var int */
+    public $OrderID;
+
+    /** @var float */
+    public $Amount;
+
+    /** @var string|null */
+    public $Opaque;
+
+    /** @var string */
+    public $CardHolderID;
+
+    /** @var string */
+    public $BackURL;
+
+    /** @var int */
+    public $PaymentType;
+}

--- a/src/Api/Ameria/Resource/OrderResource.php
+++ b/src/Api/Ameria/Resource/OrderResource.php
@@ -5,6 +5,9 @@ namespace Ngs\AmeriaPayment\Api\Ameria\Resource;
 use GuzzleHttp\RequestOptions;
 use Ngs\AmeriaPayment\Api\Ameria\Request\Struct\InitPayment;
 use Ngs\AmeriaPayment\Api\Ameria\Request\Struct\PaymentDetails;
+use Ngs\AmeriaPayment\Api\Ameria\Request\Struct\ConfirmPayment;
+use Ngs\AmeriaPayment\Api\Ameria\Request\Struct\CancelPayment;
+use Ngs\AmeriaPayment\Api\Ameria\Request\Struct\MakeBindingPayment;
 use Ngs\AmeriaPayment\Api\Ameria\BaseResource;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -42,6 +45,21 @@ class OrderResource extends BaseResource
     public function getPaymentDetails(PaymentDetails $data): ResponseInterface
     {
         return $this->client->post("$this->uri/$this->endpoint/GetPaymentDetails", [RequestOptions::JSON => $data]);
+    }
+
+    public function confirmPayment(ConfirmPayment $data): ResponseInterface
+    {
+        return $this->client->post("$this->uri/$this->endpoint/ConfirmPayment", [RequestOptions::JSON => $data]);
+    }
+
+    public function cancelPayment(CancelPayment $data): ResponseInterface
+    {
+        return $this->client->post("$this->uri/$this->endpoint/CancelPayment", [RequestOptions::JSON => $data]);
+    }
+
+    public function makeBindingPayment(MakeBindingPayment $data): ResponseInterface
+    {
+        return $this->client->post("$this->uri/$this->endpoint/MakeBindingPayment", [RequestOptions::JSON => $data]);
     }
 
 }

--- a/src/Api/Ameria/Response/Struct/MakeBindingPayment.php
+++ b/src/Api/Ameria/Response/Struct/MakeBindingPayment.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Ngs\AmeriaPayment\Api\Ameria\Response\Struct;
+
+class MakeBindingPayment extends PaymentDetails
+{
+}

--- a/src/Api/Ameria/Response/Struct/OperationResponse.php
+++ b/src/Api/Ameria/Response/Struct/OperationResponse.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Ngs\AmeriaPayment\Api\Ameria\Response\Struct;
+
+class OperationResponse extends BaseResponseStruct
+{
+    /** @var string */
+    public $ResponseCode;
+
+    /** @var string|null */
+    public $ResponseMessage;
+
+    /** @var string|null */
+    public $Opaque;
+}

--- a/src/Checkout/Payment/AmeriaPaymentHandler.php
+++ b/src/Checkout/Payment/AmeriaPaymentHandler.php
@@ -4,6 +4,7 @@ namespace Ngs\AmeriaPayment\Checkout\Payment;
 
 use Ngs\AmeriaPayment\Api\Base\Exception\ApiException;
 use Ngs\AmeriaPayment\Components\PaymentManager;
+use Ngs\AmeriaPayment\Components\PluginConfig\PluginConfigStruct;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler;
 use Shopware\Core\Checkout\Payment\Cart\AsyncPaymentTransactionStruct;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\AsynchronousPaymentHandlerInterface;
@@ -74,6 +75,11 @@ class AmeriaPaymentHandler implements AsynchronousPaymentHandlerInterface
 
         $transactionId = $transaction->getOrderTransaction()->getId();
 
-        $this->transactionStateHandler->paid($transactionId, $salesChannelContext->getContext());
+        $pluginConfig = $this->paymentManager->getPluginConfig($salesChannelContext->getSalesChannelId());
+        if ($pluginConfig->freezePayments) {
+            $this->transactionStateHandler->authorize($transactionId, $salesChannelContext->getContext());
+        } else {
+            $this->transactionStateHandler->paid($transactionId, $salesChannelContext->getContext());
+        }
     }
 }

--- a/src/Components/PaymentManager.php
+++ b/src/Components/PaymentManager.php
@@ -52,6 +52,11 @@ class PaymentManager
         $this->pluginConfigService = $pluginConfigService;
     }
 
+    public function getPluginConfig(string $salesChannelId): PluginConfigStruct
+    {
+        return new PluginConfigStruct($this->pluginConfigService, $salesChannelId);
+    }
+
     /**
      * Init payment and return external gateway url
      *
@@ -116,6 +121,18 @@ class PaymentManager
         }
 
         $this->orderTransactionEntityManager->setMdOrderIdCustomField($transaction->getOrderTransaction()->getId(), $responseObj->MDOrderID, $salesChannelContext->getContext());
+    }
+
+    public function capture(string $paymentId, float $amount, SalesChannelContext $salesChannelContext): void
+    {
+        $pluginConfig = new PluginConfigStruct($this->pluginConfigService, $salesChannelContext->getSalesChannelId());
+        $this->paymentBuilderManager->confirmPayment($pluginConfig, $paymentId, $amount);
+    }
+
+    public function cancel(string $paymentId, SalesChannelContext $salesChannelContext): void
+    {
+        $pluginConfig = new PluginConfigStruct($this->pluginConfigService, $salesChannelContext->getSalesChannelId());
+        $this->paymentBuilderManager->cancelPayment($pluginConfig, $paymentId);
     }
 
     /**

--- a/src/Components/PluginConfig/PluginConfigStruct.php
+++ b/src/Components/PluginConfig/PluginConfigStruct.php
@@ -10,6 +10,8 @@ use Shopware\Core\Framework\Struct\Struct;
 class PluginConfigStruct extends Struct
 {
     public bool $testMode;
+    public bool $enableCardBinding;
+    public bool $freezePayments;
     public string $clientId;
     public string $username;
     public string $password;
@@ -24,6 +26,8 @@ class PluginConfigStruct extends Struct
     {
         $pluginConfig = $pluginConfigService->getAll($salesChannelId);
         $this->testMode = !empty($pluginConfig['testMode']);
+        $this->enableCardBinding = !empty($pluginConfig['enableCardBinding']);
+        $this->freezePayments = !empty($pluginConfig['freezePayments']);
 
         if ($this->testMode) {
             $this->clientId = $pluginConfig['testClientId'] ?? '';

--- a/src/Core/ScheduledTask/CaptureFrozenPaymentsTask.php
+++ b/src/Core/ScheduledTask/CaptureFrozenPaymentsTask.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Ngs\AmeriaPayment\Core\ScheduledTask;
+
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
+
+class CaptureFrozenPaymentsTask extends ScheduledTask
+{
+    public static function getTaskName(): string
+    {
+        return 'ngs.ameria.capture_frozen_payments';
+    }
+
+    public static function getDefaultInterval(): int
+    {
+        return 3600; // hourly
+    }
+}

--- a/src/Core/ScheduledTask/CaptureFrozenPaymentsTaskHandler.php
+++ b/src/Core/ScheduledTask/CaptureFrozenPaymentsTaskHandler.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Ngs\AmeriaPayment\Core\ScheduledTask;
+
+use Ngs\AmeriaPayment\Components\PaymentManager;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionCollection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
+
+class CaptureFrozenPaymentsTaskHandler extends ScheduledTaskHandler
+{
+    private EntityRepository $orderTransactionRepository;
+    private PaymentManager $paymentManager;
+
+    public function __construct(EntityRepository $scheduledTaskRepository, EntityRepository $orderTransactionRepository, PaymentManager $paymentManager)
+    {
+        parent::__construct($scheduledTaskRepository);
+        $this->orderTransactionRepository = $orderTransactionRepository;
+        $this->paymentManager = $paymentManager;
+    }
+
+    public static function getHandledMessages(): iterable
+    {
+        return [CaptureFrozenPaymentsTask::class];
+    }
+
+    public function run(): void
+    {
+        $context = Context::createDefaultContext();
+
+        // TODO: Fetch authorized transactions and capture or cancel based on order and delivery status
+        // This is a placeholder to demonstrate scheduling logic.
+    }
+}

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -18,6 +18,35 @@
             <helpText lang="ru-RU">Включить тестовый режим</helpText>
         </input-field>
     </card>
+
+    <card>
+        <title>Payment options</title>
+        <title lang="ru-RU">Параметры оплаты</title>
+        <title lang="hy-AM">Վճարման կարգավորումներ</title>
+
+        <input-field type="bool">
+            <name>enableCardBinding</name>
+            <label>Enable card binding</label>
+            <label lang="hy-AM">Միացնել քարտի կցումը</label>
+            <label lang="ru-RU">Включить сохранение карт</label>
+            <defaultValue>false</defaultValue>
+            <helpText>Allow customers to bind cards for future payments</helpText>
+            <helpText lang="hy-AM">Թույլատրել հաճախորդներին կցել քարտերը հաջորդ վճարումների համար</helpText>
+            <helpText lang="ru-RU">Разрешить клиентам сохранять карты для будущих платежей</helpText>
+        </input-field>
+
+        <input-field type="bool">
+            <name>freezePayments</name>
+            <label>Enable payment freezing</label>
+            <label lang="hy-AM">Միացնել վճարման սառեցումը</label>
+            <label lang="ru-RU">Включить заморозку платежей</label>
+            <defaultValue>false</defaultValue>
+            <helpText>Authorize payments and capture after shipping</helpText>
+            <helpText lang="hy-AM">Ավտորիզացնել վճարումները և գանձել առաքումից հետո</helpText>
+            <helpText lang="ru-RU">Авторизовать платежи и списывать после отправки</helpText>
+        </input-field>
+    </card>
+
     <card>
         <title>Live API configurations</title>
         <title lang="ru-RU">Конфигурации Live API</title>

--- a/src/Resources/config/services/scheduled.xml
+++ b/src/Resources/config/services/scheduled.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Ngs\AmeriaPayment\Core\ScheduledTask\CaptureFrozenPaymentsTask"/>
+        <service id="Ngs\AmeriaPayment\Core\ScheduledTask\CaptureFrozenPaymentsTaskHandler">
+            <argument type="service" id="scheduled_task.repository"/>
+            <argument type="service" id="order_transaction.repository"/>
+            <argument type="service" id="Ngs\AmeriaPayment\Components\PaymentManager"/>
+            <tag name="messenger.message_handler"/>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
## Summary
- add plugin config switches for card binding and payment freezing
- wire Ameria API calls for confirm, cancel and binding payments
- scaffold cron task to capture or release frozen transactions

## Testing
- `php -l src/Api/Ameria/Request/Struct/ConfirmPayment.php`
- `php -l src/Api/Ameria/Request/Struct/CancelPayment.php`
- `php -l src/Api/Ameria/Request/Struct/MakeBindingPayment.php`
- `php -l src/Api/Ameria/Response/Struct/OperationResponse.php`
- `php -l src/Api/Ameria/Response/Struct/MakeBindingPayment.php`
- `php -l src/Core/ScheduledTask/CaptureFrozenPaymentsTask.php`
- `php -l src/Core/ScheduledTask/CaptureFrozenPaymentsTaskHandler.php`
- `php -l src/Components/PaymentManager.php`
- `php -l src/Checkout/Payment/AmeriaPaymentHandler.php`
- `php -l src/Components/Api/Ameria/PaymentBuilderManager.php`
- `php -l src/Api/Ameria/Resource/OrderResource.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68a4f2aedd90832588f6d53d1f4a7977