### PR TITLE
Add detailed logging for payment operations

### DIFF
--- a/src/Resources/config/services/managers.xml
+++ b/src/Resources/config/services/managers.xml
@@ -9,6 +9,7 @@
             <argument id="Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStateHandler"
                       type="service"/>
             <argument id="Ngs\AmeriaPayment\Components\PaymentManager" type="service"/>
+            <argument id="ngs_ameria_payment.logger" type="service"/>
             <tag name="shopware.payment.method.async"/>
         </service>
 
@@ -20,6 +21,7 @@
             <argument id="Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface"
                       type="service"/>
             <argument id="Ngs\AmeriaPayment\Components\PluginConfig\PluginConfigService" type="service"/>
+            <argument id="ngs_ameria_payment.logger" type="service"/>
         </service>
 
         <service id="Ngs\AmeriaPayment\Components\Api\Ameria\PaymentBuilderManager">


### PR DESCRIPTION
## Summary
- add monolog logger to payment handler and manager
- log payment init, finalize, capture and cancel events
- wire logger services into manager and handler

## Testing
- `php -l src/Components/PaymentManager.php`
- `php -l src/Checkout/Payment/AmeriaPaymentHandler.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68a5177225dc8325b77d29bae9ef380c