### PR TITLE
feat: add payment binding infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# NgsAmeriaPayment
+
+This plugin integrates the Ameria PSP payment gateway for Shopware 6.
+
+## Payment Bindings
+
+The plugin now provides a `PaymentBinding` entity allowing customers to store encrypted payment tokens returned by the PSP. Bindings can be created from payment responses and queried or managed via the `BindingService`.
+
+### Security
+
+Tokens are stored encrypted using AES-256-GCM with the Shopware `APP_SECRET`.

--- a/src/Core/PaymentBinding/PaymentBindingCollection.php
+++ b/src/Core/PaymentBinding/PaymentBindingCollection.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Ngs\AmeriaPayment\Core\PaymentBinding;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+/**
+ * @method void                     add(PaymentBindingEntity $entity)
+ * @method void                     set(string $key, PaymentBindingEntity $entity)
+ * @method PaymentBindingEntity[]   getIterator()
+ * @method PaymentBindingEntity[]   getElements()
+ * @method PaymentBindingEntity|null get(string $key)
+ * @method PaymentBindingEntity|null first()
+ * @method PaymentBindingEntity|null last()
+ */
+class PaymentBindingCollection extends EntityCollection
+{
+    protected function getExpectedClass(): string
+    {
+        return PaymentBindingEntity::class;
+    }
+}

--- a/src/Core/PaymentBinding/PaymentBindingDefinition.php
+++ b/src/Core/PaymentBinding/PaymentBindingDefinition.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types=1);
+
+namespace Ngs\AmeriaPayment\Core\PaymentBinding;
+
+use Shopware\Core\Checkout\Customer\CustomerDefinition;
+use Shopware\Core\Checkout\Payment\PaymentMethodDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\CreatedAtField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedAtField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\UuidField;
+use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
+
+/**
+ * Definition for saved payment bindings
+ */
+class PaymentBindingDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = 'ngs_payment_binding';
+
+    /**
+     * @inheritDoc
+     */
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCollectionClass(): string
+    {
+        return PaymentBindingCollection::class;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getEntityClass(): string
+    {
+        return PaymentBindingEntity::class;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new UuidField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
+            (new FkField('customer_id', 'customerId', CustomerDefinition::class))->addFlags(new Required()),
+            (new FkField('payment_method_id', 'paymentMethodId', PaymentMethodDefinition::class))->addFlags(new Required()),
+            new FkField('sales_channel_id', 'salesChannelId', SalesChannelDefinition::class),
+            (new StringField('provider', 'provider'))->addFlags(new Required()),
+            (new StringField('binding_token', 'bindingToken'))->addFlags(new Required()),
+            (new StringField('masked_pan', 'maskedPan'))->addFlags(new Required()),
+            (new StringField('card_scheme', 'cardScheme'))->addFlags(new Required()),
+            (new IntField('expiry_month', 'expiryMonth'))->addFlags(new Required()),
+            (new IntField('expiry_year', 'expiryYear'))->addFlags(new Required()),
+            (new BoolField('is_default', 'isDefault'))->addFlags(new Required()),
+            new JsonField('meta', 'meta'),
+            new CreatedAtField(),
+            new UpdatedAtField(),
+        ]);
+    }
+}

--- a/src/Core/PaymentBinding/PaymentBindingEntity.php
+++ b/src/Core/PaymentBinding/PaymentBindingEntity.php
@@ -1,0 +1,136 @@
+<?php declare(strict_types=1);
+
+namespace Ngs\AmeriaPayment\Core\PaymentBinding;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
+
+/**
+ * Entity representing stored payment binding
+ */
+class PaymentBindingEntity extends Entity
+{
+    use EntityIdTrait;
+
+    protected string $customerId;
+    protected string $paymentMethodId;
+    protected ?string $salesChannelId = null;
+    protected string $provider;
+    protected string $bindingToken;
+    protected string $maskedPan;
+    protected string $cardScheme;
+    protected int $expiryMonth;
+    protected int $expiryYear;
+    protected bool $isDefault = false;
+    protected ?array $meta = null;
+
+    public function getCustomerId(): string
+    {
+        return $this->customerId;
+    }
+
+    public function setCustomerId(string $customerId): void
+    {
+        $this->customerId = $customerId;
+    }
+
+    public function getPaymentMethodId(): string
+    {
+        return $this->paymentMethodId;
+    }
+
+    public function setPaymentMethodId(string $paymentMethodId): void
+    {
+        $this->paymentMethodId = $paymentMethodId;
+    }
+
+    public function getSalesChannelId(): ?string
+    {
+        return $this->salesChannelId;
+    }
+
+    public function setSalesChannelId(?string $salesChannelId): void
+    {
+        $this->salesChannelId = $salesChannelId;
+    }
+
+    public function getProvider(): string
+    {
+        return $this->provider;
+    }
+
+    public function setProvider(string $provider): void
+    {
+        $this->provider = $provider;
+    }
+
+    public function getBindingToken(): string
+    {
+        return $this->bindingToken;
+    }
+
+    public function setBindingToken(string $bindingToken): void
+    {
+        $this->bindingToken = $bindingToken;
+    }
+
+    public function getMaskedPan(): string
+    {
+        return $this->maskedPan;
+    }
+
+    public function setMaskedPan(string $maskedPan): void
+    {
+        $this->maskedPan = $maskedPan;
+    }
+
+    public function getCardScheme(): string
+    {
+        return $this->cardScheme;
+    }
+
+    public function setCardScheme(string $cardScheme): void
+    {
+        $this->cardScheme = $cardScheme;
+    }
+
+    public function getExpiryMonth(): int
+    {
+        return $this->expiryMonth;
+    }
+
+    public function setExpiryMonth(int $expiryMonth): void
+    {
+        $this->expiryMonth = $expiryMonth;
+    }
+
+    public function getExpiryYear(): int
+    {
+        return $this->expiryYear;
+    }
+
+    public function setExpiryYear(int $expiryYear): void
+    {
+        $this->expiryYear = $expiryYear;
+    }
+
+    public function isDefault(): bool
+    {
+        return $this->isDefault;
+    }
+
+    public function setIsDefault(bool $isDefault): void
+    {
+        $this->isDefault = $isDefault;
+    }
+
+    public function getMeta(): ?array
+    {
+        return $this->meta;
+    }
+
+    public function setMeta(?array $meta): void
+    {
+        $this->meta = $meta;
+    }
+}

--- a/src/Migration/Migration202407181200AddPaymentBinding.php
+++ b/src/Migration/Migration202407181200AddPaymentBinding.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Ngs\AmeriaPayment\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Throwable;
+
+class Migration202407181200AddPaymentBinding extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 202407181200;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $sql = <<<SQL
+CREATE TABLE IF NOT EXISTS `ngs_payment_binding` (
+    `id` BINARY(16) NOT NULL,
+    `customer_id` BINARY(16) NOT NULL,
+    `payment_method_id` BINARY(16) NOT NULL,
+    `sales_channel_id` BINARY(16) NULL,
+    `provider` VARCHAR(255) NOT NULL,
+    `binding_token` VARCHAR(255) NOT NULL,
+    `masked_pan` VARCHAR(255) NOT NULL,
+    `card_scheme` VARCHAR(255) NOT NULL,
+    `expiry_month` INT NOT NULL,
+    `expiry_year` INT NOT NULL,
+    `is_default` TINYINT(1) NOT NULL DEFAULT 0,
+    `meta` JSON NULL,
+    `created_at` DATETIME(3) NOT NULL,
+    `updated_at` DATETIME(3) NULL,
+    PRIMARY KEY (`id`),
+    KEY `idx.binding.customer` (`customer_id`),
+    KEY `idx.binding.payment_method` (`payment_method_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+SQL;
+
+        try {
+            $connection->executeStatement($sql);
+        } catch (Throwable $e) {
+            // ignore
+        }
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // no destructive update
+    }
+}

--- a/src/Resources/config/services/payment_binding.xml
+++ b/src/Resources/config/services/payment_binding.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Ngs\AmeriaPayment\Core\PaymentBinding\PaymentBindingDefinition">
+            <tag name="shopware.entity.definition" entity="ngs_payment_binding"/>
+        </service>
+
+        <service id="Ngs\AmeriaPayment\Service\EncryptionService">
+            <argument>%env(APP_SECRET)%</argument>
+        </service>
+
+        <service id="Ngs\AmeriaPayment\Service\BindingService">
+            <argument type="service" id="ngs_payment_binding.repository"/>
+            <argument type="service" id="Ngs\AmeriaPayment\Service\EncryptionService"/>
+        </service>
+    </services>
+</container>

--- a/src/Service/BindingService.php
+++ b/src/Service/BindingService.php
@@ -1,0 +1,112 @@
+<?php declare(strict_types=1);
+
+namespace Ngs\AmeriaPayment\Service;
+
+use Ngs\AmeriaPayment\Core\PaymentBinding\PaymentBindingCollection;
+use Ngs\AmeriaPayment\Core\PaymentBinding\PaymentBindingEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionEntity;
+use InvalidArgumentException;
+use RuntimeException;
+
+class BindingService
+{
+    private EntityRepository $repository;
+    private EncryptionService $encryptionService;
+
+    public function __construct(EntityRepository $repository, EncryptionService $encryptionService)
+    {
+        $this->repository = $repository;
+        $this->encryptionService = $encryptionService;
+    }
+
+    public function createBindingFromPSPResponse(OrderTransactionEntity $transaction, CustomerEntity $customer, array $pspData, Context $context): PaymentBindingEntity
+    {
+        if (empty($pspData['bindingToken'])) {
+            throw new InvalidArgumentException('PSP response does not contain binding token');
+        }
+
+        $bindingId = Uuid::randomHex();
+
+        $data = [
+            'id' => $bindingId,
+            'customerId' => $customer->getId(),
+            'paymentMethodId' => $transaction->getPaymentMethodId(),
+            'salesChannelId' => $transaction->getOrder() ? $transaction->getOrder()->getSalesChannelId() : null,
+            'provider' => $pspData['provider'] ?? 'ameria',
+            'bindingToken' => $this->encryptionService->encrypt($pspData['bindingToken']),
+            'maskedPan' => $pspData['maskedPan'] ?? '',
+            'cardScheme' => $pspData['cardScheme'] ?? '',
+            'expiryMonth' => (int) ($pspData['expiryMonth'] ?? 0),
+            'expiryYear' => (int) ($pspData['expiryYear'] ?? 0),
+            'isDefault' => (bool)($pspData['isDefault'] ?? false),
+            'meta' => $pspData['meta'] ?? null,
+        ];
+
+        $this->repository->create([$data], $context);
+
+        /** @var PaymentBindingEntity|null $created */
+        $created = $this->repository->search(new Criteria([$bindingId]), $context)->first();
+
+        if (!$created) {
+            throw new RuntimeException('Failed to create payment binding');
+        }
+
+        return $created;
+    }
+
+    public function listBindings(string $customerId, ?string $paymentMethodId, ?string $salesChannelId, Context $context): PaymentBindingCollection
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('customerId', $customerId));
+        if ($paymentMethodId) {
+            $criteria->addFilter(new EqualsFilter('paymentMethodId', $paymentMethodId));
+        }
+        if ($salesChannelId) {
+            $criteria->addFilter(new EqualsFilter('salesChannelId', $salesChannelId));
+        }
+
+        /** @var PaymentBindingCollection $collection */
+        $collection = $this->repository->search($criteria, $context)->getEntities();
+
+        return $collection;
+    }
+
+    public function setDefault(string $bindingId, Context $context): void
+    {
+        /** @var PaymentBindingEntity|null $binding */
+        $binding = $this->repository->search(new Criteria([$bindingId]), $context)->first();
+        if (!$binding) {
+            throw new InvalidArgumentException('Binding not found');
+        }
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('customerId', $binding->getCustomerId()));
+        $criteria->addFilter(new EqualsFilter('paymentMethodId', $binding->getPaymentMethodId()));
+        $criteria->addFilter(new NotFilter(MultiFilter::CONNECTION_AND, [new EqualsFilter('id', $bindingId)]));
+        $others = $this->repository->search($criteria, $context)->getEntities();
+        $updates = [];
+        foreach ($others as $other) {
+            $updates[] = ['id' => $other->getId(), 'isDefault' => false];
+        }
+        $updates[] = ['id' => $bindingId, 'isDefault' => true];
+        $this->repository->update($updates, $context);
+    }
+
+    public function deleteBinding(string $bindingId, Context $context): void
+    {
+        $this->repository->delete([['id' => $bindingId]], $context);
+    }
+
+    public function getDecryptedToken(PaymentBindingEntity $binding): string
+    {
+        return $this->encryptionService->decrypt($binding->getBindingToken());
+    }
+}

--- a/src/Service/EncryptionService.php
+++ b/src/Service/EncryptionService.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Ngs\AmeriaPayment\Service;
+
+use RuntimeException;
+
+/**
+ * Simple wrapper around OpenSSL AES-256-GCM encryption using APP_SECRET
+ */
+class EncryptionService
+{
+    private string $secret;
+
+    public function __construct(string $appSecret)
+    {
+        $this->secret = hash('sha256', $appSecret, true);
+    }
+
+    public function encrypt(string $plaintext): string
+    {
+        $iv = random_bytes(12);
+        $tag = '';
+        $cipher = openssl_encrypt($plaintext, 'aes-256-gcm', $this->secret, OPENSSL_RAW_DATA, $iv, $tag);
+        if ($cipher === false) {
+            throw new RuntimeException('Encryption failed');
+        }
+        return base64_encode($iv . $tag . $cipher);
+    }
+
+    public function decrypt(string $payload): string
+    {
+        $data = base64_decode($payload, true);
+        if ($data === false || strlen($data) < 28) {
+            throw new RuntimeException('Invalid payload');
+        }
+        $iv = substr($data, 0, 12);
+        $tag = substr($data, 12, 16);
+        $cipher = substr($data, 28);
+        $plain = openssl_decrypt($cipher, 'aes-256-gcm', $this->secret, OPENSSL_RAW_DATA, $iv, $tag);
+        if ($plain === false) {
+            throw new RuntimeException('Decryption failed');
+        }
+        return $plain;
+    }
+}


### PR DESCRIPTION
## Summary
- add PaymentBinding custom entity and migration
- secure token encryption service and CRUD binding service
- document binding support

## Testing
- `php -l src/Core/PaymentBinding/PaymentBindingDefinition.php`
- `php -l src/Core/PaymentBinding/PaymentBindingEntity.php`
- `php -l src/Core/PaymentBinding/PaymentBindingCollection.php`
- `php -l src/Migration/Migration202407181200AddPaymentBinding.php`
- `php -l src/Service/EncryptionService.php`
- `php -l src/Service/BindingService.php`
- `composer test` *(fails: Command "test" is not defined.)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68abd7961f7c8325a56fc8fa5e9f8b01